### PR TITLE
Make polyfill's test more readable

### DIFF
--- a/node/__tests__/common/polyfill/btoa.test.ts
+++ b/node/__tests__/common/polyfill/btoa.test.ts
@@ -1,11 +1,13 @@
 import {btoa} from '../../../common/polyfill/btoa';
 
 test('if btoa can convert string into base64 string', () => {
+  // Assert
   expect(btoa('hello')).toEqual('aGVsbG8='); // with padding
   expect(btoa('abc')).toEqual('YWJj'); // without padding
 });
 
 test('if btoa can throw an error if string contains characters outside of the Latin1 range.', () => {
+  // Assert
   expect(() => btoa('あ')).toThrow(
     'The string contains characters outside of the Latin1 range.'
   );

--- a/node/__tests__/common/polyfill/text_encoder.test.ts
+++ b/node/__tests__/common/polyfill/text_encoder.test.ts
@@ -1,17 +1,25 @@
 import {TextEncoder} from '../../../common/polyfill/text_encoder';
 
 test('if TextEncoder can encode the `hello world` string', () => {
+  // Arrange
   const encoder = new TextEncoder();
+
+  // Act
   const encoded = encoder.encode('hello world');
 
+  // Assert
   expect(encoded).toEqual(
     new Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
   );
 });
 
 test('if TextEncoder can encode the empty string', () => {
+  // Arrange
   const encoder = new TextEncoder();
+
+  // Act
   const encoded = encoder.encode('');
 
+  // Assert
   expect(encoded).toEqual(new Uint8Array());
 });

--- a/node/common/polyfill/index.ts
+++ b/node/common/polyfill/index.ts
@@ -1,0 +1,2 @@
+export * from './btoa';
+export * from './text_encoder';

--- a/node/common/polyfill/index.ts
+++ b/node/common/polyfill/index.ts
@@ -1,2 +1,0 @@
-export * from './btoa';
-export * from './text_encoder';


### PR DESCRIPTION
This PR revises the test files for polyfill.

We have two polyfills `bota` and `TextEncoder`.
They are implemented with pure JavaScript thus they are runnable on Node and Browsers.

There's no logical change.

They are identical to https://github.com/scalar-labs/scalardl-javascript-sdk-base/tree/master/polyfill