### PR TITLE
Define Signer and Validator

### DIFF
--- a/node/common/signature.ts
+++ b/node/common/signature.ts
@@ -1,0 +1,7 @@
+export interface SignatureSigner {
+  sign(data: Uint8Array): Promise<Uint8Array>;
+}
+
+export interface SignatureValidator {
+  validate(data: Uint8Array, signature: Uint8Array): Promise<boolean>;
+}


### PR DESCRIPTION
This PR defines two interfaces `SignatureValidator` and `SignatureSigner`.

The "implementations" of these interfaces will be proposed later.

This is used to abstract the signer and validator for Node (based on the elliptic package) and Browser (based on WebCrypto).