### PR TITLE
Add scalar.proto and its Types

### DIFF
--- a/scalar.proto
+++ b/scalar.proto
@@ -1,0 +1,249 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.scalar.dl.rpc";
+option java_outer_classname = "ScalarProto";
+
+import "google/protobuf/empty.proto";
+
+package rpc;
+
+// Ledger service definition.
+service Ledger {
+    rpc RegisterContract (ContractRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc ListContracts (ContractsListingRequest) returns (ContractsListingResponse) {
+    }
+    rpc ExecuteContract (ContractExecutionRequest) returns (ContractExecutionResponse) {
+    }
+    rpc ValidateLedger (LedgerValidationRequest) returns (LedgerValidationResponse) {
+    }
+    rpc RetrieveAssetProof (AssetProofRetrievalRequest) returns (AssetProofRetrievalResponse) {
+    }
+    rpc AbortExecution (ExecutionAbortRequest) returns (ExecutionAbortResponse) {
+    }
+}
+
+service LedgerPrivileged {
+    rpc RegisterCert (CertificateRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc RegisterFunction (FunctionRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc RetrieveState (StateRetrievalRequest) returns (StateRetrievalResponse) {
+    }
+}
+
+service Auditor {
+    rpc RegisterContract (ContractRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc ListContracts (ContractsListingRequest) returns (ContractsListingResponse) {
+    }
+    rpc OrderExecution(ContractExecutionRequest) returns (ExecutionOrderingResponse) {
+    }
+    rpc ValidateExecution(ExecutionValidationRequest) returns (ContractExecutionResponse) {
+    }
+}
+
+service AuditorPrivileged {
+    rpc RegisterCert (CertificateRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+}
+
+message CertificateRegistrationRequest {
+    string cert_holder_id = 1;
+    uint32 cert_version = 2;
+    string cert_pem = 3;
+    bool via_proxy = 4;
+}
+
+message FunctionRegistrationRequest {
+    string function_id = 1;
+    string function_binary_name = 2;
+    bytes function_byte_code = 3;
+    bool via_proxy = 4;
+}
+
+message ContractRegistrationRequest {
+    string contract_id = 1;
+    string contract_binary_name = 2;
+    bytes contract_byte_code = 3;
+    string contract_properties = 4;
+    string cert_holder_id = 5;
+    uint32 cert_version = 6;
+    bytes signature = 7;
+    bool via_proxy = 8;
+}
+
+message ContractsListingRequest {
+    string cert_holder_id = 1;
+    uint32 cert_version = 2;
+    string contract_id = 3;
+    bytes signature = 4;
+}
+
+message ContractExecutionRequest {
+    string contract_id = 1;
+    string contract_argument = 2;
+    string cert_holder_id = 3;
+    uint32 cert_version = 4;
+    string function_argument = 5;
+    bytes signature = 6;
+    bytes auditor_signature = 7;
+    bool use_function_ids = 8;
+    repeated string function_ids = 9;
+    string nonce = 10;
+}
+
+message LedgerValidationRequest {
+    string asset_id = 1;
+    uint32 start_age = 2;
+    uint32 end_age = 3;
+    string cert_holder_id = 4;
+    uint32 cert_version = 5;
+    bytes signature = 6;
+}
+
+message AssetProofRetrievalRequest {
+    string asset_id = 1;
+    int32 age = 2;
+    string cert_holder_id = 3;
+    uint32 cert_version = 4;
+    bytes signature = 5;
+}
+
+message ExecutionAbortRequest {
+    string nonce = 1;
+    string cert_holder_id = 2;
+    uint32 cert_version = 3;
+    bytes signature = 4;
+}
+
+message StateRetrievalRequest {
+    string transaction_id = 1;
+}
+
+message ExecutionValidationRequest {
+    ContractExecutionRequest request = 1;
+    repeated AssetProof proofs = 2;
+}
+
+message ContractsListingResponse {
+    string json = 1;
+}
+
+message ContractExecutionResponse {
+    string contract_result = 1; // the result of contract execution
+    repeated AssetProof proofs = 2; // proofs given from the ledger server
+    string function_result = 3; // the result of function execution
+}
+
+message LedgerValidationResponse {
+    uint32 status_code = 1;
+    AssetProof proof = 2; // a proof given from the ledger server
+}
+
+message AssetProofRetrievalResponse {
+    AssetProof proof = 1;
+    string ledger_name = 2;
+}
+
+message AssetProof {
+    string asset_id = 1;
+    uint32 age = 2;
+    string nonce = 3;
+    string input = 4;
+    bytes hash = 5;
+    bytes prev_hash = 6;
+    bytes signature = 7;
+}
+
+enum TransactionState {
+    TRANSACTION_STATE_UNSPECIFIED = 0;
+    TRANSACTION_STATE_COMMITTED = 1;
+    TRANSACTION_STATE_ABORTED = 2;
+    TRANSACTION_STATE_UNKNOWN = 3;
+}
+
+message ExecutionAbortResponse {
+    TransactionState state = 1;
+}
+
+message StateRetrievalResponse {
+    TransactionState state = 1;
+}
+
+message Status {
+    uint32 code = 1;
+    string message = 2;
+}
+
+message ExecutionOrderingResponse {
+    bytes signature = 1;
+}
+
+// Proof registry service definition.
+service ProofRegistry {
+    rpc RegisterProofs (ProofsRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc RetrieveProof (ProofRetrievalRequest) returns (ProofRetrievalResponse) {
+    }
+}
+
+message ProofsRegistrationRequest {
+    repeated AssetProof proofs = 1;
+}
+
+message ProofRetrievalRequest {
+    string asset_id = 1;
+}
+
+message ProofRetrievalResponse {
+    AssetProof proof = 1;
+}
+
+service Proxy {
+    rpc RegisterCert (CertificateRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc RegisterContract (ContractRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc RegisterFunction (FunctionRegistrationRequest) returns (google.protobuf.Empty) {
+    }
+    rpc ExecuteContract (ContractExecutionRequest) returns (ContractExecutionResponse) {
+    }
+    rpc ValidateLedgers (LedgersValidationRequest) returns (LedgersValidationResponse) {
+    }
+    rpc ProxyResponse (IdentifiableResponse) returns (google.protobuf.Empty) {
+    }
+}
+
+message ReturnableRequest {
+    string id = 1;
+    oneof request {
+        CertificateRegistrationRequest certificate_registration_request = 2;
+        ContractRegistrationRequest contract_registration_request = 3;
+        FunctionRegistrationRequest function_registration_request = 4;
+        ContractExecutionRequest contract_execution_request = 5;
+    }
+    string hostname = 6;
+    uint32 port = 7;
+    bytes signature = 8; // TODO: to be deleted later
+}
+
+message LedgersValidationRequest {
+    string asset_id = 1;
+    string cert_holder_id = 2;
+    uint32 cert_version = 3;
+    bytes signature = 4;
+}
+
+message IdentifiableResponse {
+    string id = 1;
+    oneof response {
+        ContractExecutionResponse contract_execution_response = 2;
+    }
+    uint32 status_code = 3;
+}
+
+message LedgersValidationResponse {
+    repeated AssetProofRetrievalResponse response = 1;
+}

--- a/scalar.proto.ts
+++ b/scalar.proto.ts
@@ -1,0 +1,71 @@
+export type CertificateRegistrationRequest = {
+  setCertHolderId: (certHolderId: string) => void;
+  setCertVersion: (certVersion: number) => void;
+  setCertPem: (certPem: string) => void;
+};
+
+export type ContractExecutionRequest = {
+  setContractId: (id: string) => void;
+  setContractArgument: (argument: string) => void;
+  setCertHolderId: (id: string) => void;
+  setCertVersion: (version: number) => void;
+  setFunctionArgument: (argument: string) => void;
+  setUseFunctionIds: (used: boolean) => void;
+  setFunctionIdsList: (list: string[]) => void;
+  setNonce: (nonce: string) => void;
+  setSignature: (signature: Uint8Array) => void;
+};
+
+export type ContractsListingRequest = {
+  setCertHolderId: (id: string) => void;
+  setCertVersion: (version: number) => void;
+  setContractId: (id: string) => void;
+  setSignature: (signature: Uint8Array) => void;
+};
+
+export type ContractRegistrationRequest = {
+  setContractId: (id: string) => void;
+  setContractBinaryName: (name: string) => void;
+  setContractByteCode: (byteCode: Uint8Array) => void;
+  setContractProperties: (properties: string) => void;
+  setCertHolderId: (id: string) => void;
+  setCertVersion: (version: number) => void;
+  setSignature: (signature: Uint8Array) => void;
+};
+
+export type ExecutionValidationRequest = {
+  setRequest: (request: ContractExecutionRequest) => void;
+  setProofsList: (proofs: AssetProof[]) => void;
+};
+
+export type FunctionRegistrationRequest = {
+  setFunctionId: (id: string) => void;
+  setFunctionBinaryName: (name: string) => void;
+  setFunctionByteCode: (byteCode: Uint8Array) => void;
+};
+
+export type LedgerValidationRequest = {
+  setAssetId: (id: string) => void;
+  setStartAge: (startAge: number) => void;
+  setEndAge: (endAge: number) => void;
+  setCertHolderId: (certHolderId: string) => void;
+  setCertVersion: (certVersion: number) => void;
+  setSignature: (signature: Uint8Array) => void;
+};
+
+export type AssetProof = {
+  setAssetId: (id: string) => void;
+  setAge: (age: number) => void;
+  setNonce: (nonce: string) => void;
+  setInput: (input: string) => void;
+  setHash: (hash: Uint8Array) => void;
+  setPrevHash: (prevHash: Uint8Array) => void;
+  setSignature: (signature: Uint8Array) => void;
+  getAssetId: () => string;
+  getAge: () => number;
+  getNonce: () => string;
+  getInput: () => string;
+  getHash_asU8: () => Uint8Array;
+  getPrevHash_asU8: () => Uint8Array;
+  getSignature_asU8: () => Uint8Array;
+};


### PR DESCRIPTION
This PR adds the latest `scalar.proto` file and its Types `scalar.proto.ts`

The reason we need `scalar.proto.ts` is the tools we used to generate the serialization files for `grpc-web` (for Browser) and `grpc-js` (for Node) can only generate JavaScript files. Therefore we need to "type" it.

`scalar.proto.ts` needs to be updated when `scalar.proto` is updated.