### PR TITLE
Add the contract and function registration builders

### DIFF
--- a/node/__tests__/common/builder/contract_registration_request.test.ts
+++ b/node/__tests__/common/builder/contract_registration_request.test.ts
@@ -1,0 +1,51 @@
+import {ContractRegistrationRequestBuilder} from '../../../common/builder';
+
+test('ContractRegisftrationRequestBuilder can build ContractRegistrationRequest', async () => {
+  // Arrange
+  const signer = {
+    sign: jest.fn(async () => new Uint8Array([7, 8, 9])),
+  };
+  const request = {
+    setContractId: jest.fn(),
+    setContractBinaryName: jest.fn(),
+    setContractByteCode: jest.fn(),
+    setContractProperties: jest.fn(),
+    setCertHolderId: jest.fn(),
+    setCertVersion: jest.fn(),
+    setSignature: jest.fn(),
+  };
+  const builder = new ContractRegistrationRequestBuilder(request, signer);
+
+  // Act
+  await builder
+    .withContractId('contractId')
+    .withContractBinaryName('contractBinaryName')
+    .withContractByteCode(new Uint8Array([1, 2, 3]))
+    .withContractProperties('contractProperties')
+    .withCertHolderId('certHolderId')
+    .withCertVersion(1)
+    .build();
+
+  // Assert
+  expect(signer.sign).toHaveBeenCalledWith(
+    new Uint8Array([
+      99, 111, 110, 116, 114, 97, 99, 116, 73, 100, 99, 111, 110, 116, 114, 97,
+      99, 116, 66, 105, 110, 97, 114, 121, 78, 97, 109, 101, 1, 2, 3, 99, 111,
+      110, 116, 114, 97, 99, 116, 80, 114, 111, 112, 101, 114, 116, 105, 101,
+      115, 99, 101, 114, 116, 72, 111, 108, 100, 101, 114, 73, 100, 0, 0, 0, 1,
+    ])
+  );
+  expect(request.setContractId).toHaveBeenCalledWith('contractId');
+  expect(request.setContractBinaryName).toHaveBeenCalledWith(
+    'contractBinaryName'
+  );
+  expect(request.setContractByteCode).toHaveBeenCalledWith(
+    new Uint8Array([1, 2, 3])
+  );
+  expect(request.setContractProperties).toHaveBeenCalledWith(
+    'contractProperties'
+  );
+  expect(request.setCertHolderId).toHaveBeenCalledWith('certHolderId');
+  expect(request.setCertVersion).toHaveBeenCalledWith(1);
+  expect(request.setSignature).toHaveBeenCalledWith(new Uint8Array([7, 8, 9]));
+});

--- a/node/__tests__/common/builder/function_registration_request.test.ts
+++ b/node/__tests__/common/builder/function_registration_request.test.ts
@@ -1,0 +1,27 @@
+import {FunctionRegistrationRequestBuilder} from '../../../common/builder';
+
+test('if FunctionRegistrationRequestBuilder can build FunctionRegistrationRequest', async () => {
+  // Arrange
+  const request = {
+    setFunctionId: jest.fn(),
+    setFunctionBinaryName: jest.fn(),
+    setFunctionByteCode: jest.fn(),
+  };
+  const builder = new FunctionRegistrationRequestBuilder(request);
+
+  // Act
+  await builder
+    .withFunctionId('functionId')
+    .withFunctionBinaryName('functionBinaryName')
+    .withFunctionByteCode(new Uint8Array([1, 2, 3]))
+    .build();
+
+  // Assert
+  expect(request.setFunctionId).toHaveBeenCalledWith('functionId');
+  expect(request.setFunctionBinaryName).toHaveBeenCalledWith(
+    'functionBinaryName'
+  );
+  expect(request.setFunctionByteCode).toHaveBeenCalledWith(
+    new Uint8Array([1, 2, 3])
+  );
+});

--- a/node/common/builder/contract_registration_request.ts
+++ b/node/common/builder/contract_registration_request.ts
@@ -1,0 +1,131 @@
+import {ContractRegistrationRequest} from '../scalar.proto';
+import {SignatureSigner} from '../signature';
+import {TextEncoder} from '../polyfill/text_encoder';
+
+export class ContractRegistrationRequestBuilder {
+  private contractId: string = '';
+  private contractBinaryName: string = '';
+  private contractByteCode: Uint8Array = new Uint8Array();
+  private contractProperties: string = '';
+  private certHolderId: string = '';
+  private certVersion: number = 0;
+
+  /**
+   * @param {ContractRegistrationRequest} request
+   * @param {SignatureSigner} signer
+   */
+  constructor(
+    private request: ContractRegistrationRequest,
+    private signer: SignatureSigner
+  ) {}
+
+  /**
+   * @param {string} id
+   * @return {ContractRegistrationRequestBuilder}
+   */
+  withContractId(id: string): ContractRegistrationRequestBuilder {
+    this.contractId = id;
+    return this;
+  }
+
+  /**
+   * @param {string} name
+   * @return {ContractRegistrationRequestBuilder}
+   */
+  withContractBinaryName(name: string): ContractRegistrationRequestBuilder {
+    this.contractBinaryName = name;
+    return this;
+  }
+
+  /**
+   * @param {Uint8Array} byteCode
+   * @return {ContractRegistrationRequestBuilder}
+   */
+  withContractByteCode(
+    byteCode: Uint8Array
+  ): ContractRegistrationRequestBuilder {
+    this.contractByteCode = byteCode;
+    return this;
+  }
+
+  /**
+   * @param {string} properties
+   * @return {ContractRegistrationRequestBuilder}
+   */
+  withContractProperties(
+    properties: string
+  ): ContractRegistrationRequestBuilder {
+    this.contractProperties = properties;
+    return this;
+  }
+
+  /**
+   * @param {string} id
+   * @return {ContractRegistrationRequestBuilder}
+   */
+  withCertHolderId(id: string): ContractRegistrationRequestBuilder {
+    this.certHolderId = id;
+    return this;
+  }
+
+  /**
+   * @param {number} version
+   * @return {ContractRegistrationRequestBuilder}
+   */
+  withCertVersion(version: number): ContractRegistrationRequestBuilder {
+    this.certVersion = version;
+    return this;
+  }
+
+  /**
+   * @return {Promise<ContractRegistrationRequest>}
+   */
+  async build(): Promise<ContractRegistrationRequest> {
+    const request = this.request;
+    request.setContractId(this.contractId);
+    request.setContractBinaryName(this.contractBinaryName);
+    request.setContractByteCode(this.contractByteCode);
+    request.setContractProperties(this.contractProperties);
+    request.setCertHolderId(this.certHolderId);
+    request.setCertVersion(this.certVersion);
+
+    const contractId = new TextEncoder().encode(this.contractId);
+    const contractBinaryName = new TextEncoder().encode(
+      this.contractBinaryName
+    );
+    const contractBytes = this.contractByteCode;
+    const contractProperties = new TextEncoder().encode(
+      this.contractProperties
+    );
+    const certHolderId = new TextEncoder().encode(this.certHolderId);
+    const view = new DataView(new ArrayBuffer(4));
+    view.setUint32(0, this.certVersion);
+    const certVersion = new Uint8Array(view.buffer);
+
+    const buffer = new Uint8Array(
+      contractId.byteLength +
+        contractBinaryName.byteLength +
+        contractBytes.byteLength +
+        contractProperties.byteLength +
+        certHolderId.byteLength +
+        certVersion.byteLength
+    );
+
+    let offset = 0;
+    buffer.set(contractId, offset);
+    offset += contractId.byteLength;
+    buffer.set(contractBinaryName, offset);
+    offset += contractBinaryName.byteLength;
+    buffer.set(contractBytes, offset);
+    offset += contractBytes.byteLength;
+    buffer.set(contractProperties, offset);
+    offset += contractProperties.byteLength;
+    buffer.set(certHolderId, offset);
+    offset += certHolderId.byteLength;
+    buffer.set(certVersion, offset);
+
+    request.setSignature(await this.signer.sign(buffer));
+
+    return request;
+  }
+}

--- a/node/common/builder/function_registration_request.ts
+++ b/node/common/builder/function_registration_request.ts
@@ -1,0 +1,54 @@
+import {FunctionRegistrationRequest} from '../scalar.proto';
+
+export class FunctionRegistrationRequestBuilder {
+  private functionId: string = '';
+  private functionBinaryName: string = '';
+  private functionByteCode: Uint8Array = new Uint8Array();
+
+  /**
+   * @param {FunctionRegistrationRequest} request
+   */
+  constructor(private request: FunctionRegistrationRequest) {}
+
+  /**
+   * Sets the ID of the function
+   * @param {string} id
+   * @return {FunctionRegistrationRequestBuilder}
+   */
+  withFunctionId(id: string): FunctionRegistrationRequestBuilder {
+    this.functionId = id;
+    return this;
+  }
+
+  /**
+   * @param {string} name
+   * @return {FunctionRegistrationRequestBuilder}
+   */
+  withFunctionBinaryName(name: string): FunctionRegistrationRequestBuilder {
+    this.functionBinaryName = name;
+    return this;
+  }
+
+  /**
+   * @param {Uint8Array} byteCode
+   * @return {FunctionRegistrationRequestBuilder}
+   */
+  withFunctionByteCode(
+    byteCode: Uint8Array
+  ): FunctionRegistrationRequestBuilder {
+    this.functionByteCode = byteCode;
+    return this;
+  }
+
+  /**
+   * @return {Promise<FunctionRegistrationRequest>}
+   */
+  async build(): Promise<FunctionRegistrationRequest> {
+    const request = this.request;
+    request.setFunctionId(this.functionId);
+    request.setFunctionBinaryName(this.functionBinaryName);
+    request.setFunctionByteCode(this.functionByteCode);
+
+    return request;
+  }
+}

--- a/node/common/builder/index.ts
+++ b/node/common/builder/index.ts
@@ -1,0 +1,2 @@
+export * from './contract_registration_request';
+export * from './function_registration_request';

--- a/node/common/scalar.proto.ts
+++ b/node/common/scalar.proto.ts
@@ -1,0 +1,1 @@
+../../scalar.proto.ts


### PR DESCRIPTION
This PR adds two ports for building the contract and function registration requests.

They are the correspondents of
- https://github.com/scalar-labs/scalardl-javascript-sdk-base/blob/master/request/builder.js#L100 (function registration request builder)
- https://github.com/scalar-labs/scalardl-javascript-sdk-base/blob/master/request/builder.js#L164 (contract registration request builder)