### PR TITLE
Add builder for certificate registration requests

### DIFF
--- a/node/__tests__/common/builder/certificate_registration_request.test.ts
+++ b/node/__tests__/common/builder/certificate_registration_request.test.ts
@@ -1,0 +1,23 @@
+import {CertificateRegistrationRequestBuilder} from '../../../common/builder';
+
+test('if CertificateRegistrationRequestBuilder can build CertificateRegistrationRequest', async () => {
+  // Arrange
+  const request = {
+    setCertHolderId: jest.fn(),
+    setCertVersion: jest.fn(),
+    setCertPem: jest.fn(),
+  };
+  const builder = new CertificateRegistrationRequestBuilder(request);
+
+  // Act
+  await builder
+    .withCertHolderId('certHolderId')
+    .withCertVersion(1)
+    .withCertPem('certPem')
+    .build();
+
+  // Asssert
+  expect(request.setCertHolderId).toHaveBeenCalledWith('certHolderId');
+  expect(request.setCertVersion).toHaveBeenCalledWith(1);
+  expect(request.setCertPem).toHaveBeenCalledWith('certPem');
+});

--- a/node/common/builder/certificate_registration_request.ts
+++ b/node/common/builder/certificate_registration_request.ts
@@ -1,0 +1,51 @@
+import {CertificateRegistrationRequest} from '../scalar.proto';
+
+export class CertificateRegistrationRequestBuilder {
+  private certHolderId: string = '';
+  private certVersion: number = 0;
+  private certPem: string = '';
+
+  /**
+   * @param {CertificateRegistrationRequest} request
+   */
+  constructor(private request: CertificateRegistrationRequest) {}
+
+  /**
+   * @param {string} id
+   * @return {CertificateRegistrationRequestBuilder}
+   */
+  withCertHolderId(id: string): CertificateRegistrationRequestBuilder {
+    this.certHolderId = id;
+    return this;
+  }
+
+  /**
+   * @param {number} version
+   * @return {CertificateRegistrationRequestBuilder}
+   */
+  withCertVersion(version: number): CertificateRegistrationRequestBuilder {
+    this.certVersion = version;
+    return this;
+  }
+
+  /**
+   * @param {string} pem
+   * @return {CertificateRegistrationRequestBuilder}
+   */
+  withCertPem(pem: string): CertificateRegistrationRequestBuilder {
+    this.certPem = pem;
+    return this;
+  }
+
+  /**
+   * @return {Promise<CertificateRegistrationRequest>}
+   */
+  async build(): Promise<CertificateRegistrationRequest> {
+    const request = this.request;
+    request.setCertHolderId(this.certHolderId);
+    request.setCertVersion(this.certVersion);
+    request.setCertPem(this.certPem);
+
+    return request;
+  }
+}

--- a/node/common/builder/index.ts
+++ b/node/common/builder/index.ts
@@ -1,0 +1,1 @@
+export * from './certificate_registration_request';

--- a/node/common/scalar.proto.ts
+++ b/node/common/scalar.proto.ts
@@ -1,0 +1,1 @@
+../../scalar.proto.ts


### PR DESCRIPTION
This PR adds a port for building certificate registration requests.

This is the correspondent of https://github.com/scalar-labs/scalardl-javascript-sdk-base/blob/master/request/builder.js#L36