### PR TITLE
Add builders for contract execution requests and execution validation requests

### DIFF
--- a/node/__tests__/common/builder/contract_execution_request.test.ts
+++ b/node/__tests__/common/builder/contract_execution_request.test.ts
@@ -1,0 +1,50 @@
+import {ContractExecutionRequestBuilder} from '../../../common/builder';
+
+test('ContractExecutionRequestBuilder can build ContractExecutionRequest', async () => {
+  // Arrange
+  const request = {
+    setContractId: jest.fn(),
+    setContractArgument: jest.fn(),
+    setCertHolderId: jest.fn(),
+    setCertVersion: jest.fn(),
+    setFunctionArgument: jest.fn(),
+    setUseFunctionIds: jest.fn(),
+    setFunctionIdsList: jest.fn(),
+    setNonce: jest.fn(),
+    setSignature: jest.fn(),
+  };
+  const signer = {
+    sign: jest.fn(async () => new Uint8Array([1, 2, 3])),
+  };
+  const builder = new ContractExecutionRequestBuilder(request, signer);
+
+  // Act
+  await builder
+    .withCertHolderId('certHolderId')
+    .withCertVersion(1)
+    .withContractId('contractId')
+    .withContractArgument('contractArgument')
+    .withUseFunctionIds(true)
+    .withFunctionIds(['functionId'])
+    .withFunctionArgument('functionArgument')
+    .withNonce('nonce')
+    .build();
+
+  // Assert
+  expect(signer.sign).toHaveBeenCalledWith(
+    new Uint8Array([
+      99, 111, 110, 116, 114, 97, 99, 116, 73, 100, 99, 111, 110, 116, 114, 97,
+      99, 116, 65, 114, 103, 117, 109, 101, 110, 116, 99, 101, 114, 116, 72,
+      111, 108, 100, 101, 114, 73, 100, 0, 0, 0, 1,
+    ])
+  );
+  expect(request.setCertHolderId).toHaveBeenCalledWith('certHolderId');
+  expect(request.setCertVersion).toHaveBeenCalledWith(1);
+  expect(request.setContractId).toHaveBeenCalledWith('contractId');
+  expect(request.setContractArgument).toHaveBeenCalledWith('contractArgument');
+  expect(request.setUseFunctionIds).toHaveBeenCalledWith(true);
+  expect(request.setFunctionIdsList).toHaveBeenCalledWith(['functionId']);
+  expect(request.setFunctionArgument).toHaveBeenCalledWith('functionArgument');
+  expect(request.setNonce).toHaveBeenCalledWith('nonce');
+  expect(request.setSignature).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+});

--- a/node/__tests__/common/builder/execution_validation_request.test.ts
+++ b/node/__tests__/common/builder/execution_validation_request.test.ts
@@ -1,0 +1,31 @@
+import {ExecutionValidationRequestBuilder} from '../../../common/builder';
+
+test('ExecutionValidationRequestBuilder can build ExecutionValidationRequest', async () => {
+  // Arrange
+  const request = {
+    setRequest: jest.fn(),
+    setProofsList: jest.fn(),
+  };
+  const contractExecutionRequest = {
+    setContractId: jest.fn(),
+    setContractArgument: jest.fn(),
+    setCertHolderId: jest.fn(),
+    setCertVersion: jest.fn(),
+    setFunctionArgument: jest.fn(),
+    setUseFunctionIds: jest.fn(),
+    setFunctionIdsList: jest.fn(),
+    setNonce: jest.fn(),
+    setSignature: jest.fn(),
+  };
+  const builder = new ExecutionValidationRequestBuilder(request);
+
+  // Act
+  await builder
+    .withContractExecutionRequest(contractExecutionRequest)
+    .withProofs(['proof'])
+    .build();
+
+  // Assert
+  expect(request.setRequest).toHaveBeenCalledWith(contractExecutionRequest);
+  expect(request.setProofsList).toHaveBeenCalledWith(['proof']);
+});

--- a/node/common/builder/contract_execution_request.ts
+++ b/node/common/builder/contract_execution_request.ts
@@ -1,0 +1,150 @@
+import {TextEncoder} from '../polyfill/text_encoder';
+import {SignatureSigner} from '../signature';
+
+export type ContractExecutionRequest = {
+  setContractId: (id: string) => void;
+  setContractArgument: (argument: string) => void;
+  setCertHolderId: (id: string) => void;
+  setCertVersion: (version: number) => void;
+  setFunctionArgument: (argument: string) => void;
+  setUseFunctionIds: (used: boolean) => void;
+  setFunctionIdsList: (list: string[]) => void;
+  setNonce: (nonce: string) => void;
+  setSignature: (signature: Uint8Array) => void;
+};
+
+export class ContractExecutionRequestBuilder {
+  request: ContractExecutionRequest;
+  signer: SignatureSigner;
+  contractId: string = '';
+  contractArgument: string = '';
+  certHolderId: string = '';
+  certVersion: number = 0;
+  functionArgument: string = '';
+  useFunctionIds: boolean = false;
+  functionIds: string[] = [];
+  nonce: string = '';
+
+  /**
+   * @param {ContractExecutionRequest} request
+   * @param {SignatureSigner} signer
+   */
+  constructor(request: ContractExecutionRequest, signer: SignatureSigner) {
+    this.request = request;
+    this.signer = signer;
+  }
+
+  /**
+   * @param {string} id
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withContractId(id: string): ContractExecutionRequestBuilder {
+    this.contractId = id;
+    return this;
+  }
+
+  /**
+   * @param {string} argument
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withContractArgument(argument: string): ContractExecutionRequestBuilder {
+    this.contractArgument = argument;
+    return this;
+  }
+
+  /**
+   * @param {string} id
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withCertHolderId(id: string): ContractExecutionRequestBuilder {
+    this.certHolderId = id;
+    return this;
+  }
+
+  /**
+   * @param {number} version
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withCertVersion(version: number): ContractExecutionRequestBuilder {
+    this.certVersion = version;
+    return this;
+  }
+
+  /**
+   * @param {string} argument
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withFunctionArgument(argument: string): ContractExecutionRequestBuilder {
+    this.functionArgument = argument;
+    return this;
+  }
+
+  /**
+   * @param {boolean} useFunctionIds
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withUseFunctionIds(useFunctionIds: boolean): ContractExecutionRequestBuilder {
+    this.useFunctionIds = useFunctionIds;
+    return this;
+  }
+
+  /**
+   * @param {string[]} functionIds
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withFunctionIds(functionIds: string[]): ContractExecutionRequestBuilder {
+    this.functionIds = functionIds;
+    return this;
+  }
+
+  /**
+   * @param {string} nonce
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withNonce(nonce: string): ContractExecutionRequestBuilder {
+    this.nonce = nonce;
+    return this;
+  }
+
+  /**
+   * @throws {Error}
+   * @return {Promise<ContractExecutionRequest>}
+   */
+  async build(): Promise<ContractExecutionRequest> {
+    const request = this.request;
+    request.setContractId(this.contractId);
+    request.setContractArgument(this.contractArgument);
+    request.setCertHolderId(this.certHolderId);
+    request.setCertVersion(this.certVersion);
+    request.setFunctionArgument(this.functionArgument);
+    request.setUseFunctionIds(this.useFunctionIds);
+    request.setFunctionIdsList(this.functionIds);
+    request.setNonce(this.nonce);
+
+    const contractIdEncoded = new TextEncoder().encode(this.contractId);
+    const contractArgument = new TextEncoder().encode(this.contractArgument);
+    const certHolderId = new TextEncoder().encode(this.certHolderId);
+    const view = new DataView(new ArrayBuffer(4));
+    view.setUint32(0, this.certVersion);
+    const certVersion = new Uint8Array(view.buffer);
+
+    const buffer = new Uint8Array(
+      contractIdEncoded.byteLength +
+        contractArgument.byteLength +
+        certHolderId.byteLength +
+        certVersion.byteLength
+    );
+    let offset = 0;
+    buffer.set(contractIdEncoded, offset);
+    offset += contractIdEncoded.byteLength;
+    buffer.set(contractArgument, offset);
+    offset += contractArgument.byteLength;
+    buffer.set(certHolderId, offset);
+    offset += certHolderId.byteLength;
+    buffer.set(certVersion, offset);
+
+    request.setSignature(await this.signer.sign(buffer));
+
+    return request;
+  }
+}

--- a/node/common/builder/execution_validation_request.ts
+++ b/node/common/builder/execution_validation_request.ts
@@ -1,0 +1,60 @@
+import {ContractExecutionRequest} from '.';
+
+export type ExecutionValidationRequest = {
+  setRequest: (request: ContractExecutionRequest) => void;
+  setProofsList: (proofs: unknown[]) => void;
+};
+
+export class ExecutionValidationRequestBuilder {
+  request: ExecutionValidationRequest;
+  contractExecutionRequest: ContractExecutionRequest = {
+    setContractId: () => {},
+    setContractArgument: () => {},
+    setCertHolderId: () => {},
+    setCertVersion: () => {},
+    setFunctionArgument: () => {},
+    setUseFunctionIds: () => {},
+    setFunctionIdsList: () => {},
+    setNonce: () => {},
+    setSignature: () => {},
+  };
+  proofs: unknown[] = [];
+
+  /**
+   * @param {ExecutionValidationRequest} request
+   */
+  constructor(request: ExecutionValidationRequest) {
+    this.request = request;
+  }
+
+  /**
+   * @param {ContractExecutionRequest} request
+   * @return {ExecutionValidationRequestBuilder}
+   */
+  withContractExecutionRequest(
+    request: ContractExecutionRequest
+  ): ExecutionValidationRequestBuilder {
+    this.contractExecutionRequest = request;
+    return this;
+  }
+
+  /**
+   * @param {Array<?>} proofs
+   * @return {ExecutionValidationRequestBuilder}
+   */
+  withProofs(proofs: unknown[]): ExecutionValidationRequestBuilder {
+    this.proofs = proofs;
+    return this;
+  }
+
+  /**
+   * @throws {Error}
+   * @return {Promise<ExecutionValidationRequest>}
+   */
+  async build(): Promise<ExecutionValidationRequest> {
+    const request = this.request;
+    request.setRequest(this.contractExecutionRequest);
+    request.setProofsList(this.proofs);
+    return request;
+  }
+}

--- a/node/common/builder/index.ts
+++ b/node/common/builder/index.ts
@@ -1,3 +1,5 @@
 export * from './certificate_registration_request';
 export * from './contract_registration_request';
 export * from './function_registration_request';
+export * from './contract_execution_request';
+export * from './execution_validation_request';


### PR DESCRIPTION
This PR adds the builders for contract execution requests and execution validation requests.

They are ports of

https://github.com/scalar-labs/scalardl-javascript-sdk-base/blob/master/request/builder.js#L518

and

https://github.com/scalar-labs/scalardl-javascript-sdk-base/blob/master/request/builder.js#L671