### PR TITLE
Avoid using jsrsasign for excoding

### DIFF
--- a/node/__tests__/common/polyfill/text_encoder.test.ts
+++ b/node/__tests__/common/polyfill/text_encoder.test.ts
@@ -23,3 +23,18 @@ test('if TextEncoder can encode the empty string', () => {
   // Assert
   expect(encoded).toEqual(new Uint8Array());
 });
+
+test('If TextEncoder can encode the `あいうえお` string', () => {
+  // Arrange
+  const encoder = new TextEncoder();
+
+  // Act
+  const encoded = encoder.encode('あいうえお');
+
+  // Assert
+  expect(encoded).toEqual(
+    new Uint8Array([
+      227, 129, 130, 227, 129, 132, 227, 129, 134, 227, 129, 136, 227, 129, 138,
+    ])
+  );
+});

--- a/node/common/polyfill/text_encoder.ts
+++ b/node/common/polyfill/text_encoder.ts
@@ -1,5 +1,3 @@
-import * as jsrsasign from 'jsrsasign';
-
 /**
  * An internal class to encode utf8 string to Uint8Array
  * @class
@@ -11,10 +9,48 @@ export class TextEncoder {
    * @return {Uint8Array}
    */
   encode(encoding: string): Uint8Array {
-    return !encoding
-      ? new Uint8Array()
-      : new Uint8Array(
-          jsrsasign.hextoArrayBuffer(jsrsasign.utf8tohex(encoding))
-        );
+    const hex = encodeURIComponentAll(encoding)
+      .replace(/%/g, '')
+      .toLocaleLowerCase();
+    const buffer = new ArrayBuffer(hex.length / 2);
+    const view = new DataView(buffer);
+
+    for (let i = 0; i < hex.length / 2; i++) {
+      view.setUint8(i, parseInt(hex.substring(i * 2, i * 2 + 2), 16));
+    }
+
+    return new Uint8Array(buffer);
   }
+}
+
+function encodeURIComponentAll(u8: string) {
+  const s = encodeURIComponent(u8);
+  let s2 = '';
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '%') {
+      s2 = s2 + s.substring(i, i + 3);
+      i = i + 2;
+    } else {
+      // A-Z a-z 0-9 - _ . ! ~ * ' ( )
+      s2 = s2 + '%' + stohex(s[i]);
+    }
+  }
+  return s2;
+}
+
+function stohex(s: string) {
+  const ba = [];
+  for (let i = 0; i < s.length; i++) {
+    ba[i] = s.charCodeAt(i);
+  }
+
+  let hex = '';
+
+  for (let i = 0; i < ba.length; i++) {
+    let hex1 = ba[i].toString(16);
+    if (hex1.length === 1) hex1 = '0' + hex1;
+    hex = hex + hex1;
+  }
+
+  return hex;
 }

--- a/node/common/polyfill/text_encoder.ts
+++ b/node/common/polyfill/text_encoder.ts
@@ -9,6 +9,10 @@ export class TextEncoder {
    * @return {Uint8Array}
    */
   encode(encoding: string): Uint8Array {
+    // This implementation is mostly copied from the following URL
+    // https://github.com/kjur/jsrsasign/blob/master/src/base64x-1.1.js
+    // The main author of jsrsasign is Kenji Urushima
+    // This code is licensed under MIT license
     const hex = encodeURIComponentAll(encoding)
       .replace(/%/g, '')
       .toLocaleLowerCase();

--- a/node/common/polyfill/text_encoder.ts
+++ b/node/common/polyfill/text_encoder.ts
@@ -9,10 +9,10 @@ export class TextEncoder {
    * @return {Uint8Array}
    */
   encode(encoding: string): Uint8Array {
-    // This implementation is mostly copied from the following URL
+    // This implementation is mostly copied from the following URL.
     // https://github.com/kjur/jsrsasign/blob/master/src/base64x-1.1.js
-    // The main author of jsrsasign is Kenji Urushima
-    // This code is licensed under MIT license
+    // The main author of jsrsasign is Kenji Urushima.
+    // This code is licensed under the MIT license.
     const hex = encodeURIComponentAll(encoding)
       .replace(/%/g, '')
       .toLocaleLowerCase();

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "@scalar-labs/scalardl-node-client-sdk",
       "version": "3.6.0",
-      "dependencies": {
-        "jsrsasign": "^10.5.27"
-      },
       "devDependencies": {
         "@types/jest": "^29.0.0",
         "@types/jsrsasign": "^10.5.2",
@@ -5464,14 +5461,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsrsasign": {
-      "version": "10.5.27",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.27.tgz",
-      "integrity": "sha512-1F4LmDeJZHYwoVvB44jEo2uZL3XuwYNzXCDOu53Ui6vqofGQ/gCYDmaxfVZtN0TGd92UKXr/BONcfrPonUIcQQ==",
-      "funding": {
-        "url": "https://github.com/kjur/jsrsasign#donations"
       }
     },
     "node_modules/kind-of": {
@@ -11315,11 +11304,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
-    },
-    "jsrsasign": {
-      "version": "10.5.27",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.27.tgz",
-      "integrity": "sha512-1F4LmDeJZHYwoVvB44jEo2uZL3XuwYNzXCDOu53Ui6vqofGQ/gCYDmaxfVZtN0TGd92UKXr/BONcfrPonUIcQQ=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/node/package.json
+++ b/node/package.json
@@ -24,8 +24,5 @@
   "scripts": {
     "test": "jest",
     "build": "tsc --build"
-  },
-  "dependencies": {
-    "jsrsasign": "^10.5.27"
   }
 }


### PR DESCRIPTION
This PR re-implements a polyfill TextEncode.encode

The reason for doing this is to avoid using the jsrsasign package.

It makes the `common` part free from any dependencies.