### PR TITLE
Port ContractExecutionResult

### DIFF
--- a/node/__tests__/common/contract_execution_result.test.ts
+++ b/node/__tests__/common/contract_execution_result.test.ts
@@ -1,0 +1,82 @@
+import {ContractExecutionResult} from '../../common/contract_execution_result';
+import {AssetProof} from '../../common/asset_proof';
+
+const mockedResponse = {
+  getContractResult: () => 'contract_result',
+  getFunctionResult: () => 'function_result',
+  getProofsList: () => [
+    {
+      setAssetId: () => {},
+      setAge: () => {},
+      setNonce: () => {},
+      setInput: () => {},
+      setHash: () => {},
+      setPrevHash: () => {},
+      setSignature: () => {},
+      getAssetId: () => 'foo',
+      getAge: () => 1,
+      getHash_asU8: () => new Uint8Array([0, 0, 0]),
+      getPrevHash_asU8: () => new Uint8Array([0, 0, 0]),
+      getNonce: () => 'nonce',
+      getInput: () => 'input',
+      getSignature_asU8: () => new Uint8Array([1, 2, 3]),
+    },
+  ],
+};
+
+jest.spyOn(mockedResponse, 'getContractResult');
+jest.spyOn(mockedResponse, 'getFunctionResult');
+jest.spyOn(mockedResponse, 'getProofsList');
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('if fromGrpcContractExecutionResponse works', () => {
+  ContractExecutionResult.fromGrpcContractExecutionResponse(mockedResponse);
+  expect(mockedResponse.getContractResult).toBeCalledTimes(1);
+  expect(mockedResponse.getFunctionResult).toBeCalledTimes(1);
+  expect(mockedResponse.getProofsList).toBeCalledTimes(1);
+});
+
+test('', () => {
+  const result = new ContractExecutionResult(
+    '{"foo": "bar"}',
+    'function_result',
+    [
+      new AssetProof(
+        'foo',
+        1,
+        'nonce',
+        'input',
+        new Uint8Array([0, 0, 0]),
+        new Uint8Array([0, 0, 0]),
+        new Uint8Array([1, 2, 3])
+      ),
+    ],
+    [
+      new AssetProof(
+        'foo',
+        1,
+        'nonce',
+        'input',
+        new Uint8Array([0, 0, 0]),
+        new Uint8Array([0, 0, 0]),
+        new Uint8Array([9, 9, 9])
+      ),
+    ]
+  );
+
+  expect(result.getContractResult()).toEqual('{"foo": "bar"}');
+  expect(result.getFunctionResult()).toEqual('function_result');
+  expect(result.getResult()).toEqual({foo: 'bar'});
+  expect(result.getProofs()[0].getSignature()).toEqual(
+    new Uint8Array([1, 2, 3])
+  );
+  expect(result.getLedgerProofs()[0].getSignature()).toEqual(
+    new Uint8Array([1, 2, 3])
+  );
+  expect(result.getAuditorProofs()[0].getSignature()).toEqual(
+    new Uint8Array([9, 9, 9])
+  );
+});

--- a/node/common/contract_execution_result.ts
+++ b/node/common/contract_execution_result.ts
@@ -1,0 +1,52 @@
+import {AssetProof} from './asset_proof';
+import {ContractExecutionResponse} from './scalar.proto';
+
+export class ContractExecutionResult {
+  constructor(
+    private contractResult: string,
+    private functionResult: string,
+    private ledgerProofs: AssetProof[],
+    private auditorProofs: AssetProof[]
+  ) {}
+
+  static fromGrpcContractExecutionResponse(
+    response: ContractExecutionResponse
+  ): ContractExecutionResult {
+    return new ContractExecutionResult(
+      response.getContractResult(),
+      response.getFunctionResult(),
+      response
+        .getProofsList()
+        .map(proof => AssetProof.fromGrpcAssetProof(proof)),
+      []
+    );
+  }
+
+  getResult(): Object {
+    return this.contractResult !== '' ? JSON.parse(this.contractResult) : {};
+  }
+
+  getContractResult(): string {
+    return this.contractResult;
+  }
+
+  getFunctionResult(): string {
+    return this.functionResult;
+  }
+
+  getProofs(): AssetProof[] {
+    return this.ledgerProofs;
+  }
+
+  getLedgerProofs(): AssetProof[] {
+    return this.ledgerProofs;
+  }
+
+  getAuditorProofs(): AssetProof[] {
+    return this.auditorProofs;
+  }
+}
+
+module.exports = {
+  ContractExecutionResult,
+};

--- a/scalar.proto.ts
+++ b/scalar.proto.ts
@@ -69,3 +69,9 @@ export type AssetProof = {
   getPrevHash_asU8: () => Uint8Array;
   getSignature_asU8: () => Uint8Array;
 };
+
+export type ContractExecutionResponse = {
+  getContractResult: () => string;
+  getFunctionResult: () => string;
+  getProofsList: () => AssetProof[];
+};


### PR DESCRIPTION
This PR adds a class ContractExecutionResult.

It's the port of https://github.com/scalar-labs/scalardl-javascript-sdk-base/blob/master/contract_execution_result.js