### PR TITLE
Remove redundant comments

### DIFF
--- a/node/common/asset_proof.ts
+++ b/node/common/asset_proof.ts
@@ -12,15 +12,6 @@ export class AssetProof {
   prevHash: Uint8Array = new Uint8Array();
   signature: Uint8Array = new Uint8Array();
 
-  /**
-   * @param {string} id
-   * @param {number} age
-   * @param {string} nonce
-   * @param {string} input
-   * @param {Uint8Array} hash
-   * @param {Uint8Array} prevHash
-   * @param {Uint8Array} signature
-   */
   constructor(
     id: string,
     age: number,
@@ -39,10 +30,6 @@ export class AssetProof {
     this.signature = signature;
   }
 
-  /**
-   * @param {GrpcAssetProof} proof
-   * @return {AssetProof}
-   */
   static fromGrpcAssetProof(proof: GrpcAssetProof): AssetProof {
     return new AssetProof(
       proof.getAssetId(),
@@ -55,59 +42,36 @@ export class AssetProof {
     );
   }
 
-  /**
-   * @return {string}
-   */
   getId(): string {
     return this.id;
   }
 
-  /**
-   * @return {number}
-   */
   getAge(): number {
     return this.age;
   }
 
-  /**
-   * @return {Uint8Array}
-   */
   getHash(): Uint8Array {
     return this.hash;
   }
 
-  /**
-   * @return {Uint8Array}
-   */
   getPrevHash(): Uint8Array {
     return this.prevHash;
   }
 
-  /**
-   * @return {string}
-   */
   getNonce(): string {
     return this.nonce;
   }
 
-  /**
-   * @return {string}
-   */
   getInput(): string {
     return this.input;
   }
 
-  /**
-   * @return {Uint8Array}
-   */
   getSignature(): Uint8Array {
     return this.signature;
   }
 
   /**
    * @deprecated
-   * @param {Uint8Array} hash
-   * @return {boolean}
    */
   hashEquals(hash: Uint8Array): boolean {
     if (!(hash instanceof Uint8Array)) {
@@ -124,10 +88,6 @@ export class AssetProof {
     return true;
   }
 
-  /**
-   * @param {AssetProof} other
-   * @return {boolean}
-   */
   valueEquals(other: AssetProof): boolean {
     if (!(other instanceof AssetProof)) {
       return false;
@@ -145,9 +105,6 @@ export class AssetProof {
     );
   }
 
-  /**
-   * @return {string}
-   */
   toString(): string {
     return (
       `AssetProof{id=${this.id},` +
@@ -162,7 +119,6 @@ export class AssetProof {
   }
 
   /**
-   * @param {SignatureValidator} validator
    * @throws {Error}
    */
   async validateWith(validator: SignatureValidator) {
@@ -183,10 +139,6 @@ export class AssetProof {
   }
 }
 
-/**
- * @param {Uint8Array} array
- * @return {string}
- */
 function uint8ArrayToBase64(array: Uint8Array): string {
   return btoa(
     Array(array.length)
@@ -196,16 +148,6 @@ function uint8ArrayToBase64(array: Uint8Array): string {
   );
 }
 
-/**
- *
- * @param {string} id
- * @param {number} age
- * @param {string} nonce
- * @param {string} input
- * @param {Uint8Array} hash
- * @param {Uint8Array} prevHash
- * @return {Uint8Array}
- */
 function serialize(
   id: string,
   age: number,

--- a/node/common/builder/certificate_registration_request.ts
+++ b/node/common/builder/certificate_registration_request.ts
@@ -5,41 +5,23 @@ export class CertificateRegistrationRequestBuilder {
   private certVersion: number = 0;
   private certPem: string = '';
 
-  /**
-   * @param {CertificateRegistrationRequest} request
-   */
   constructor(private request: CertificateRegistrationRequest) {}
 
-  /**
-   * @param {string} id
-   * @return {CertificateRegistrationRequestBuilder}
-   */
   withCertHolderId(id: string): CertificateRegistrationRequestBuilder {
     this.certHolderId = id;
     return this;
   }
 
-  /**
-   * @param {number} version
-   * @return {CertificateRegistrationRequestBuilder}
-   */
   withCertVersion(version: number): CertificateRegistrationRequestBuilder {
     this.certVersion = version;
     return this;
   }
 
-  /**
-   * @param {string} pem
-   * @return {CertificateRegistrationRequestBuilder}
-   */
   withCertPem(pem: string): CertificateRegistrationRequestBuilder {
     this.certPem = pem;
     return this;
   }
 
-  /**
-   * @return {Promise<CertificateRegistrationRequest>}
-   */
   async build(): Promise<CertificateRegistrationRequest> {
     const request = this.request;
     request.setCertHolderId(this.certHolderId);

--- a/node/common/builder/contract_execution_request.ts
+++ b/node/common/builder/contract_execution_request.ts
@@ -25,82 +25,46 @@ export class ContractExecutionRequestBuilder {
   functionIds: string[] = [];
   nonce: string = '';
 
-  /**
-   * @param {ContractExecutionRequest} request
-   * @param {SignatureSigner} signer
-   */
   constructor(request: ContractExecutionRequest, signer: SignatureSigner) {
     this.request = request;
     this.signer = signer;
   }
 
-  /**
-   * @param {string} id
-   * @return {ContractExecutionRequestBuilder}
-   */
   withContractId(id: string): ContractExecutionRequestBuilder {
     this.contractId = id;
     return this;
   }
 
-  /**
-   * @param {string} argument
-   * @return {ContractExecutionRequestBuilder}
-   */
   withContractArgument(argument: string): ContractExecutionRequestBuilder {
     this.contractArgument = argument;
     return this;
   }
 
-  /**
-   * @param {string} id
-   * @return {ContractExecutionRequestBuilder}
-   */
   withCertHolderId(id: string): ContractExecutionRequestBuilder {
     this.certHolderId = id;
     return this;
   }
 
-  /**
-   * @param {number} version
-   * @return {ContractExecutionRequestBuilder}
-   */
   withCertVersion(version: number): ContractExecutionRequestBuilder {
     this.certVersion = version;
     return this;
   }
 
-  /**
-   * @param {string} argument
-   * @return {ContractExecutionRequestBuilder}
-   */
   withFunctionArgument(argument: string): ContractExecutionRequestBuilder {
     this.functionArgument = argument;
     return this;
   }
 
-  /**
-   * @param {boolean} useFunctionIds
-   * @return {ContractExecutionRequestBuilder}
-   */
   withUseFunctionIds(useFunctionIds: boolean): ContractExecutionRequestBuilder {
     this.useFunctionIds = useFunctionIds;
     return this;
   }
 
-  /**
-   * @param {string[]} functionIds
-   * @return {ContractExecutionRequestBuilder}
-   */
   withFunctionIds(functionIds: string[]): ContractExecutionRequestBuilder {
     this.functionIds = functionIds;
     return this;
   }
 
-  /**
-   * @param {string} nonce
-   * @return {ContractExecutionRequestBuilder}
-   */
   withNonce(nonce: string): ContractExecutionRequestBuilder {
     this.nonce = nonce;
     return this;
@@ -108,7 +72,6 @@ export class ContractExecutionRequestBuilder {
 
   /**
    * @throws {Error}
-   * @return {Promise<ContractExecutionRequest>}
    */
   async build(): Promise<ContractExecutionRequest> {
     const request = this.request;

--- a/node/common/builder/contract_listing_request.ts
+++ b/node/common/builder/contract_listing_request.ts
@@ -15,45 +15,26 @@ export class ContractsListingRequestBuilder {
   certVersion: number = 0;
   contractId: string = '';
 
-  /**
-   * @param {ContractsListingRequest} request
-   * @param {SignatureSigner} signer
-   */
   constructor(request: ContractsListingRequest, signer: SignatureSigner) {
     this.request = request;
     this.signer = signer;
   }
 
-  /**
-   * @param {string} id
-   * @return {ContractsListingRequestBuilder}
-   */
   withCertHolderId(id: string): ContractsListingRequestBuilder {
     this.certHolderId = id;
     return this;
   }
 
-  /**
-   * @param {number} version
-   * @return {ContractsListingRequestBuilder}
-   */
   withCertVersion(version: number): ContractsListingRequestBuilder {
     this.certVersion = version;
     return this;
   }
 
-  /**
-   * @param {string} id
-   * @return {ContractsListingRequestBuilder}
-   */
   withContractId(id: string): ContractsListingRequestBuilder {
     this.contractId = id;
     return this;
   }
 
-  /**
-   * @return {Promise<ContractsListingRequest>}
-   */
   async build(): Promise<ContractsListingRequest> {
     const request = this.request;
     request.setCertHolderId(this.certHolderId);

--- a/node/common/builder/contract_registration_request.ts
+++ b/node/common/builder/contract_registration_request.ts
@@ -10,37 +10,21 @@ export class ContractRegistrationRequestBuilder {
   private certHolderId: string = '';
   private certVersion: number = 0;
 
-  /**
-   * @param {ContractRegistrationRequest} request
-   * @param {SignatureSigner} signer
-   */
   constructor(
     private request: ContractRegistrationRequest,
     private signer: SignatureSigner
   ) {}
 
-  /**
-   * @param {string} id
-   * @return {ContractRegistrationRequestBuilder}
-   */
   withContractId(id: string): ContractRegistrationRequestBuilder {
     this.contractId = id;
     return this;
   }
 
-  /**
-   * @param {string} name
-   * @return {ContractRegistrationRequestBuilder}
-   */
   withContractBinaryName(name: string): ContractRegistrationRequestBuilder {
     this.contractBinaryName = name;
     return this;
   }
 
-  /**
-   * @param {Uint8Array} byteCode
-   * @return {ContractRegistrationRequestBuilder}
-   */
   withContractByteCode(
     byteCode: Uint8Array
   ): ContractRegistrationRequestBuilder {
@@ -48,10 +32,6 @@ export class ContractRegistrationRequestBuilder {
     return this;
   }
 
-  /**
-   * @param {string} properties
-   * @return {ContractRegistrationRequestBuilder}
-   */
   withContractProperties(
     properties: string
   ): ContractRegistrationRequestBuilder {
@@ -59,27 +39,16 @@ export class ContractRegistrationRequestBuilder {
     return this;
   }
 
-  /**
-   * @param {string} id
-   * @return {ContractRegistrationRequestBuilder}
-   */
   withCertHolderId(id: string): ContractRegistrationRequestBuilder {
     this.certHolderId = id;
     return this;
   }
 
-  /**
-   * @param {number} version
-   * @return {ContractRegistrationRequestBuilder}
-   */
   withCertVersion(version: number): ContractRegistrationRequestBuilder {
     this.certVersion = version;
     return this;
   }
 
-  /**
-   * @return {Promise<ContractRegistrationRequest>}
-   */
   async build(): Promise<ContractRegistrationRequest> {
     const request = this.request;
     request.setContractId(this.contractId);

--- a/node/common/builder/execution_validation_request.ts
+++ b/node/common/builder/execution_validation_request.ts
@@ -20,17 +20,10 @@ export class ExecutionValidationRequestBuilder {
   };
   proofs: unknown[] = [];
 
-  /**
-   * @param {ExecutionValidationRequest} request
-   */
   constructor(request: ExecutionValidationRequest) {
     this.request = request;
   }
 
-  /**
-   * @param {ContractExecutionRequest} request
-   * @return {ExecutionValidationRequestBuilder}
-   */
   withContractExecutionRequest(
     request: ContractExecutionRequest
   ): ExecutionValidationRequestBuilder {
@@ -38,19 +31,11 @@ export class ExecutionValidationRequestBuilder {
     return this;
   }
 
-  /**
-   * @param {Array<?>} proofs
-   * @return {ExecutionValidationRequestBuilder}
-   */
   withProofs(proofs: unknown[]): ExecutionValidationRequestBuilder {
     this.proofs = proofs;
     return this;
   }
 
-  /**
-   * @throws {Error}
-   * @return {Promise<ExecutionValidationRequest>}
-   */
   async build(): Promise<ExecutionValidationRequest> {
     const request = this.request;
     request.setRequest(this.contractExecutionRequest);

--- a/node/common/builder/function_registration_request.ts
+++ b/node/common/builder/function_registration_request.ts
@@ -5,34 +5,18 @@ export class FunctionRegistrationRequestBuilder {
   private functionBinaryName: string = '';
   private functionByteCode: Uint8Array = new Uint8Array();
 
-  /**
-   * @param {FunctionRegistrationRequest} request
-   */
   constructor(private request: FunctionRegistrationRequest) {}
 
-  /**
-   * Sets the ID of the function
-   * @param {string} id
-   * @return {FunctionRegistrationRequestBuilder}
-   */
   withFunctionId(id: string): FunctionRegistrationRequestBuilder {
     this.functionId = id;
     return this;
   }
 
-  /**
-   * @param {string} name
-   * @return {FunctionRegistrationRequestBuilder}
-   */
   withFunctionBinaryName(name: string): FunctionRegistrationRequestBuilder {
     this.functionBinaryName = name;
     return this;
   }
 
-  /**
-   * @param {Uint8Array} byteCode
-   * @return {FunctionRegistrationRequestBuilder}
-   */
   withFunctionByteCode(
     byteCode: Uint8Array
   ): FunctionRegistrationRequestBuilder {
@@ -40,9 +24,6 @@ export class FunctionRegistrationRequestBuilder {
     return this;
   }
 
-  /**
-   * @return {Promise<FunctionRegistrationRequest>}
-   */
   async build(): Promise<FunctionRegistrationRequest> {
     const request = this.request;
     request.setFunctionId(this.functionId);

--- a/node/common/builder/ledger_validation_request.ts
+++ b/node/common/builder/ledger_validation_request.ts
@@ -19,63 +19,36 @@ export class LedgerValidationRequestBuilder {
   certHolderId: string = '';
   certVersion: number = 0;
 
-  /**
-   * @param {LedgerValidationRequest} request
-   * @param {SignatureSigner} signer
-   */
   constructor(request: LedgerValidationRequest, signer: SignatureSigner) {
     this.request = request;
     this.signer = signer;
   }
 
-  /**
-   * @param {string} id
-   * @return {LedgerValidationRequestBuilder}
-   */
   withAssetId(id: string): LedgerValidationRequestBuilder {
     this.assetId = id;
     return this;
   }
 
-  /**
-   * @param {number} startAge
-   * @return {LedgerValidationRequestBuilder}
-   */
   withStartAge(startAge: number): LedgerValidationRequestBuilder {
     this.startAge = startAge;
     return this;
   }
 
-  /**
-   * @param {number} endAge
-   * @return {LedgerValidationRequestBuilder}
-   */
   withEndAge(endAge: number): LedgerValidationRequestBuilder {
     this.endAge = endAge;
     return this;
   }
 
-  /**
-   * @param {string} id
-   * @return {LedgerValidationRequestBuilder}
-   */
   withCertHolderId(id: string): LedgerValidationRequestBuilder {
     this.certHolderId = id;
     return this;
   }
 
-  /**
-   * @param {number} version
-   * @return {LedgerValidationRequestBuilder}
-   */
   withCertVersion(version: number): LedgerValidationRequestBuilder {
     this.certVersion = version;
     return this;
   }
 
-  /**
-   * @return {Promise<LedgerValidationRequest>}
-   */
   async build(): Promise<LedgerValidationRequest> {
     const request = this.request;
     request.setAssetId(this.assetId);

--- a/node/common/polyfill/btoa.ts
+++ b/node/common/polyfill/btoa.ts
@@ -1,7 +1,5 @@
 /**
  * Convert a plain text to the base64-encoded string
- * @param {string} converting
- * @return {string}
  * @throws {Error}
  */
 export function btoa(converting: string): string {

--- a/node/common/polyfill/text_encoder.ts
+++ b/node/common/polyfill/text_encoder.ts
@@ -5,8 +5,6 @@
 export class TextEncoder {
   /**
    * To encode utf8 to Uint8Array
-   * @param {string} encoding
-   * @return {Uint8Array}
    */
   encode(encoding: string): Uint8Array {
     // This implementation is mostly copied from the following URL.


### PR DESCRIPTION
This PR removes many comments used to describe the types of argument and returned value.

I think they are redundant and they can be removed.