### PR TITLE
Port ContractExecutionArgument

### DIFF
--- a/node/__tests__/common/contract_execution_argument.test.ts
+++ b/node/__tests__/common/contract_execution_argument.test.ts
@@ -1,0 +1,17 @@
+import {format} from '../../common/contract_execution_argument';
+
+test('if format works properly', () => {
+  expect(format('nonce', ['f1', 'f2'], 'stringArgument')).toEqual(
+    'V2\u0001nonce\u0003f1\u0002f2\u0003stringArgument'
+  );
+
+  expect(format('nonce', ['f1', 'f2'], {foo: 'bar'})).toEqual(
+    'V2\u0001nonce\u0003f1\u0002f2\u0003{"foo":"bar"}'
+  );
+});
+
+test('if format can throw error', () => {
+  expect(() => format('nonce', ['f1', 'f2'], 1)).toThrowError(
+    'argument must be a string or an object'
+  );
+});

--- a/node/common/contract_execution_argument.ts
+++ b/node/common/contract_execution_argument.ts
@@ -1,0 +1,28 @@
+const ARGUMENT_VERSION_PREFIX = 'V';
+const ARGUMENT_FORMAT_VERSION = '2';
+const NONCE_SEPARATOR = '\u0001';
+const FUNCTION_SEPARATOR = '\u0002';
+const ARGUMENT_SEPARATOR = '\u0003';
+
+export function format(
+  nonce: string,
+  functionIds: string[],
+  argument: string | Object
+): string {
+  if (typeof argument !== 'string' && typeof argument !== 'object') {
+    throw new Error('argument must be a string or an object');
+  }
+
+  return (
+    ARGUMENT_VERSION_PREFIX +
+    ARGUMENT_FORMAT_VERSION +
+    NONCE_SEPARATOR +
+    nonce +
+    ARGUMENT_SEPARATOR +
+    `${functionIds
+      .filter(v => typeof v === 'string')
+      .join(FUNCTION_SEPARATOR)}` +
+    ARGUMENT_SEPARATOR +
+    `${typeof argument === 'object' ? JSON.stringify(argument) : argument}`
+  );
+}


### PR DESCRIPTION
This PR creates the ContractExecutionArgument class. It is a port of https://github.com/scalar-labs/scalardl-javascript-sdk-base/blob/master/contract_execution_argument.js