### PR TITLE
Export all necessary definitions of the `common` part

### DIFF
--- a/node/common/index.ts
+++ b/node/common/index.ts
@@ -1,0 +1,7 @@
+export {ClientServiceBase} from './client_service_base';
+export {ClientError} from './client_error';
+export {StatusCode} from './status_code';
+export {ContractExecutionResult} from './contract_execution_result';
+export {LedgerValidationResult} from './ledger_validation_result';
+export {AssetProof} from './asset_proof';
+export {ClientConfig, CLIENT_PROPERTIES_FIELD} from './client_config';


### PR DESCRIPTION
This PR creates the index file for the common part.

It's to make importing statements simpler.

This PR has nothing related to logic change but the JavaScript concerns, so I would ask Yves to review it to save others' time.