### PR TITLE
Implement ClientServiceWithIndexedDb

### DIFF
--- a/web/__tests__/e2e/client_service_indexeddb.test.js
+++ b/web/__tests__/e2e/client_service_indexeddb.test.js
@@ -1,0 +1,237 @@
+/* eslint-disable node/no-unpublished-require */
+/* eslint-disable no-undef */
+const {ClientServiceWithIndexedDb} = require('../../dist/index');
+const Dexie = require('dexie').default;
+
+const db = new Dexie('scalar');
+db.version(1).stores({keystore: 'id', certstore: 'id'});
+
+async function presetKey(certHolderId, certVersion) {
+  const generatedKeyPair = await window.crypto.subtle.generateKey(
+    {name: 'ECDSA', namedCurve: 'P-256'},
+    false, // cannot extractable
+    ['sign', 'verify']
+  );
+  const privateKey = generatedKeyPair.privateKey;
+
+  db.keystore.put({id: `${certHolderId}_${certVersion}`, key: privateKey});
+}
+
+async function presetCert(certHolderId, certVersion) {
+  db.certstore.put({id: `${certHolderId}_${certVersion}`, cert: 'cert'});
+}
+
+async function presetKeyAndCert(certHolderId, certVersion) {
+  await presetKey(certHolderId, certVersion);
+  await presetCert(certHolderId, certVersion);
+}
+
+it('can fill key and cert into properties if they are stored in indexedDB', async () => {
+  // Arrange
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+  };
+
+  await presetKeyAndCert(certHolderId, certVersion);
+
+  // Act & Assert
+  // Since ClientConfig check the properties, we can consider it pass the test if we can create a ClientService
+  await expectAsync(
+    ClientServiceWithIndexedDb.create(properties)
+  ).toBeResolved();
+});
+
+it('can store key and cert into indexedDB', async () => {
+  // Arrange
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const cert =
+    '-----BEGIN CERTIFICATE-----\n' +
+    'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
+    'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
+    'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
+    'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
+    'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
+    'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
+    'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
+    'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
+    'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
+    'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
+    'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
+    'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
+    'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
+    'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n' +
+    '-----END CERTIFICATE-----\n';
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+    'scalar.dl.client.private_key_pem':
+      '-----BEGIN EC PRIVATE KEY-----\n' +
+      'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
+      'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
+      'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n' +
+      '-----END EC PRIVATE KEY-----\n',
+    'scalar.dl.client.cert_pem': cert,
+  };
+  const id = `${certHolderId}_${certVersion}`;
+
+  // Act
+  const kBefore = await db.keystore.get(id);
+  const cBefore = await db.certstore.get(id);
+  await ClientServiceWithIndexedDb.create(properties);
+  const kAfter = await db.keystore.get(id);
+  const cAfter = await db.certstore.get(id);
+
+  // Assert
+  expect(kBefore).toBeUndefined();
+  expect(kAfter).toBeDefined();
+  expect(kAfter.key).toBeInstanceOf(CryptoKey);
+  expect(cBefore).toBeUndefined();
+  expect(cAfter.cert).toEqual(cert);
+});
+
+it('can store CryptoKey into indexedDB', async () => {
+  // Arrange
+  const generatedKeyPair = await window.crypto.subtle.generateKey(
+    {name: 'ECDSA', namedCurve: 'P-256'},
+    false, // cannot extractable
+    ['sign', 'verify']
+  );
+
+  const key = generatedKeyPair.privateKey;
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+    'scalar.dl.client.private_key_cryptokey': key,
+    'scalar.dl.client.cert_pem': 'cert',
+  };
+  const id = `${certHolderId}_${certVersion}`;
+
+  // Act
+  const before = await db.keystore.get(id);
+  await ClientServiceWithIndexedDb.create(properties);
+  const after = await db.keystore.get(id);
+
+  // Assert
+  expect(before).toBeUndefined();
+  expect(after).toBeDefined();
+  expect(after.key).toEqual(key);
+});
+
+it('should throw error if the key can not be found in indexedDB', async () => {
+  // Arrange
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+  };
+
+  // Act & Assert
+  await expectAsync(
+    ClientServiceWithIndexedDb.create(properties)
+  ).toBeRejectedWithError('Can not find key from indexedDB');
+});
+
+it('should throw error if the key stored in indexedDB is not CryptoKey', async () => {
+  // Arrange
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+  };
+  const id = `${certHolderId}_${certVersion}`;
+  db.keystore.put({id: id, key: 'key'});
+
+  // Act & Assert
+  await expectAsync(
+    ClientServiceWithIndexedDb.create(properties)
+  ).toBeRejectedWithError('The key from indexedDB is not CryptoKey');
+});
+
+it('should throw error if the cert can not be found in indexedDB', async () => {
+  // Arrange
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+  };
+  await presetKey(certHolderId, certVersion);
+
+  // Act & Assert
+  await expectAsync(
+    ClientServiceWithIndexedDb.create(properties)
+  ).toBeRejectedWithError('Can not find certificate from indexedDB');
+});
+
+it('should throw error if the cert stored in indexedDB is not string', async () => {
+  // Arrange
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+  };
+  const id = `${certHolderId}_${certVersion}`;
+  await presetKey(certHolderId, certVersion);
+  db.certstore.put({id: id, cert: 1});
+
+  // Act & Assert
+  await expectAsync(
+    ClientServiceWithIndexedDb.create(properties)
+  ).toBeRejectedWithError('The certificate from indexedDB is not string');
+});
+
+it('can delete key and cert from indexedDB', async () => {
+  // Arrange
+  const certHolderId = `${new Date().getTime()}`;
+  const certVersion = 1;
+  const properties = {
+    'scalar.dl.client.server.host': '127.0.0.1',
+    'scalar.dl.client.server.port': 50051,
+    'scalar.dl.client.server.privileged_port': 50052,
+    'scalar.dl.client.cert_holder_id': certHolderId,
+    'scalar.dl.client.cert_version': certVersion,
+  };
+  const id = `${certHolderId}_${certVersion}`;
+
+  // Act
+  await presetKeyAndCert(certHolderId, certVersion);
+  const clientService = await ClientServiceWithIndexedDb.create(properties);
+
+  const before = await db.keystore.get(id);
+  await clientService.deleteIndexedDb();
+  const after = await db.keystore.get(id);
+
+  // Assert
+  expect(before).toBeDefined();
+  expect(after).toBeUndefined();
+});

--- a/web/__tests__/e2e/client_service_indexeddb.test.js
+++ b/web/__tests__/e2e/client_service_indexeddb.test.js
@@ -26,7 +26,7 @@ async function presetKeyAndCert(certHolderId, certVersion) {
   await presetCert(certHolderId, certVersion);
 }
 
-it('can fill key and cert into properties if they are stored in indexedDB', async () => {
+it('can fill key and cert into properties if they are stored in IndexedDB', async () => {
   // Arrange
   const certHolderId = `${new Date().getTime()}`;
   const certVersion = 1;
@@ -47,7 +47,7 @@ it('can fill key and cert into properties if they are stored in indexedDB', asyn
   ).toBeResolved();
 });
 
-it('can store key and cert into indexedDB', async () => {
+it('can store key and cert into IndexedDB', async () => {
   // Arrange
   const certHolderId = `${new Date().getTime()}`;
   const certVersion = 1;
@@ -99,7 +99,7 @@ it('can store key and cert into indexedDB', async () => {
   expect(cAfter.cert).toEqual(cert);
 });
 
-it('can store CryptoKey into indexedDB', async () => {
+it('can store CryptoKey into IndexedDB', async () => {
   // Arrange
   const generatedKeyPair = await window.crypto.subtle.generateKey(
     {name: 'ECDSA', namedCurve: 'P-256'},
@@ -132,7 +132,7 @@ it('can store CryptoKey into indexedDB', async () => {
   expect(after.key).toEqual(key);
 });
 
-it('should throw error if the key can not be found in indexedDB', async () => {
+it('should throw error if the key can not be found in IndexedDB', async () => {
   // Arrange
   const certHolderId = `${new Date().getTime()}`;
   const certVersion = 1;
@@ -147,10 +147,10 @@ it('should throw error if the key can not be found in indexedDB', async () => {
   // Act & Assert
   await expectAsync(
     ClientServiceWithIndexedDb.create(properties)
-  ).toBeRejectedWithError('Can not find key from indexedDB');
+  ).toBeRejectedWithError('Can not find key from IndexedDB');
 });
 
-it('should throw error if the key stored in indexedDB is not CryptoKey', async () => {
+it('should throw error if the key stored in IndexedDB is not CryptoKey', async () => {
   // Arrange
   const certHolderId = `${new Date().getTime()}`;
   const certVersion = 1;
@@ -167,10 +167,10 @@ it('should throw error if the key stored in indexedDB is not CryptoKey', async (
   // Act & Assert
   await expectAsync(
     ClientServiceWithIndexedDb.create(properties)
-  ).toBeRejectedWithError('The key from indexedDB is not CryptoKey');
+  ).toBeRejectedWithError('The key from IndexedDB is not CryptoKey');
 });
 
-it('should throw error if the cert can not be found in indexedDB', async () => {
+it('should throw error if the cert can not be found in IndexedDB', async () => {
   // Arrange
   const certHolderId = `${new Date().getTime()}`;
   const certVersion = 1;
@@ -186,10 +186,10 @@ it('should throw error if the cert can not be found in indexedDB', async () => {
   // Act & Assert
   await expectAsync(
     ClientServiceWithIndexedDb.create(properties)
-  ).toBeRejectedWithError('Can not find certificate from indexedDB');
+  ).toBeRejectedWithError('Can not find certificate from IndexedDB');
 });
 
-it('should throw error if the cert stored in indexedDB is not string', async () => {
+it('should throw error if the cert stored in IndexedDB is not string', async () => {
   // Arrange
   const certHolderId = `${new Date().getTime()}`;
   const certVersion = 1;
@@ -207,10 +207,10 @@ it('should throw error if the cert stored in indexedDB is not string', async () 
   // Act & Assert
   await expectAsync(
     ClientServiceWithIndexedDb.create(properties)
-  ).toBeRejectedWithError('The certificate from indexedDB is not string');
+  ).toBeRejectedWithError('The certificate from IndexedDB is not string');
 });
 
-it('can delete key and cert from indexedDB', async () => {
+it('can delete key and cert from IndexedDB', async () => {
   // Arrange
   const certHolderId = `${new Date().getTime()}`;
   const certVersion = 1;

--- a/web/client_service_indexeddb.ts
+++ b/web/client_service_indexeddb.ts
@@ -46,7 +46,7 @@ export class ClientServiceWithIndexedDb extends ClientService {
       const item = await db.keystore.get(id);
 
       if (!item) {
-        throw new Error('Can not find key from indexedDB');
+        throw new Error('Can not find key from IndexedDB');
       }
 
       if (!(item.key instanceof CryptoKey)) {

--- a/web/client_service_indexeddb.ts
+++ b/web/client_service_indexeddb.ts
@@ -1,0 +1,111 @@
+import Dexie, {Table} from 'dexie';
+import {KEYUTIL, b64utohex} from 'jsrsasign';
+import {Properties, CLIENT_PROPERTIES_FIELD} from './common/client_config';
+import {ClientService} from './client_service';
+import {isNonEmptyString, isInteger} from './common/polyfill/is';
+
+const KEYSTORE_DATABASE_NAME = 'scalar';
+
+class ScalarIndexedDb extends Dexie {
+  keystore!: Table<{id: string; key: CryptoKey}, string>;
+  certstore!: Table<{id: string; cert: string}, string>;
+
+  constructor() {
+    super(KEYSTORE_DATABASE_NAME);
+    this.version(1).stores({keystore: 'id', certstore: 'id'});
+  }
+}
+
+export class ClientServiceWithIndexedDb extends ClientService {
+  static async create(properties: Properties) {
+    const holderId = properties[CLIENT_PROPERTIES_FIELD.CERT_HOLDER_ID];
+    const certVersion = properties[CLIENT_PROPERTIES_FIELD.CERT_VERSION];
+
+    if (!isNonEmptyString(holderId) || !isInteger(certVersion)) {
+      throw new Error(
+        `${CLIENT_PROPERTIES_FIELD.CERT_HOLDER_ID} (string) and ${CLIENT_PROPERTIES_FIELD.CERT_VERSION} (integer) are required`
+      );
+    }
+
+    const cryptoKey = properties[
+      CLIENT_PROPERTIES_FIELD.PRIVATE_KEY_CRYPTOKEY
+    ] as CryptoKey;
+    const keyPem = properties[
+      CLIENT_PROPERTIES_FIELD.PRIVATE_KEY_PEM
+    ] as string;
+    const certPem = properties[CLIENT_PROPERTIES_FIELD.CERT_PEM] as string;
+    const id = `${holderId}_${certVersion}`;
+
+    const db = new ScalarIndexedDb();
+
+    let key: CryptoKey;
+    if (cryptoKey || keyPem) {
+      key = cryptoKey || (await toCryptoKeyFromJwk(toJwkFromPkcs1(keyPem)));
+      await db.keystore.put({id: id, key: key});
+    } else {
+      const item = await db.keystore.get(id);
+
+      if (!item) {
+        throw new Error('Can not find key from indexedDB');
+      }
+
+      if (!(item.key instanceof CryptoKey)) {
+        throw new Error('The key from indexedDB is not CryptoKey');
+      }
+
+      key = item && item.key;
+    }
+    properties[CLIENT_PROPERTIES_FIELD.PRIVATE_KEY_CRYPTOKEY] = key;
+    delete properties[CLIENT_PROPERTIES_FIELD.PRIVATE_KEY_PEM];
+
+    if (certPem) {
+      await db.certstore.put({id: id, cert: certPem});
+    } else {
+      const got = await db.certstore.get(id);
+      if (!got) {
+        throw new Error('Can not find certificate from indexedDB');
+      }
+
+      if (!isNonEmptyString(got.cert)) {
+        throw new Error('The certificate from indexedDB is not string');
+      }
+
+      properties[CLIENT_PROPERTIES_FIELD.CERT_PEM] = got.cert;
+    }
+
+    return new ClientServiceWithIndexedDb(properties);
+  }
+
+  async deleteIndexedDb() {
+    const id = `${this.config.getCertHolderId()}_${this.config.getCertVersion()}`;
+
+    const db = new ScalarIndexedDb();
+
+    await db.keystore.delete(id);
+    await db.certstore.delete(id);
+  }
+
+  private constructor(properties: Properties) {
+    super(properties);
+  }
+}
+
+async function toCryptoKeyFromJwk(jwk: JsonWebKey): Promise<CryptoKey> {
+  return window.crypto.subtle.importKey(
+    'jwk',
+    jwk,
+    {name: 'ECDSA', namedCurve: 'P-256'},
+    false, // extractable is false (which means unextractable)
+    ['sign']
+  );
+}
+
+function toJwkFromPkcs1(pkcs1: string): JsonWebKey {
+  pkcs1 = pkcs1
+    .replace('-----BEGIN EC PRIVATE KEY-----', '')
+    .replace('-----END EC PRIVATE KEY-----', '')
+    .replace(/\r\n/g, '');
+  const key = KEYUTIL.getKey(b64utohex(pkcs1), null, 'pkcs5prv');
+
+  return KEYUTIL.getJWKFromKey(key as never);
+}

--- a/web/client_service_indexeddb.ts
+++ b/web/client_service_indexeddb.ts
@@ -50,7 +50,7 @@ export class ClientServiceWithIndexedDb extends ClientService {
       }
 
       if (!(item.key instanceof CryptoKey)) {
-        throw new Error('The key from indexedDB is not CryptoKey');
+        throw new Error('The key from IndexedDB is not CryptoKey');
       }
 
       key = item && item.key;
@@ -63,11 +63,11 @@ export class ClientServiceWithIndexedDb extends ClientService {
     } else {
       const got = await db.certstore.get(id);
       if (!got) {
-        throw new Error('Can not find certificate from indexedDB');
+        throw new Error('Can not find certificate from IndexedDB');
       }
 
       if (!isNonEmptyString(got.cert)) {
-        throw new Error('The certificate from indexedDB is not string');
+        throw new Error('The certificate from IndexedDB is not string');
       }
 
       properties[CLIENT_PROPERTIES_FIELD.CERT_PEM] = got.cert;

--- a/web/index.ts
+++ b/web/index.ts
@@ -5,3 +5,4 @@ export {ContractExecutionResult} from './common/contract_execution_result';
 export {LedgerValidationResult} from './common/ledger_validation_result';
 export {AssetProof} from './common/asset_proof';
 export {ClientError} from './common/client_error';
+export {ClientServiceWithIndexedDb} from './client_service_indexeddb';

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,13 +9,14 @@
       "version": "3.6.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "dexie": "^3.2.3",
         "google-protobuf": "^3.21.2",
         "grpc-web": "^1.4.2",
-        "jsrsasign": "^10.6.1",
+        "jsrsasign": "^10.8.6",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@types/jsrsasign": "^10.5.5",
+        "@types/jsrsasign": "^10.5.8",
         "@types/uuid": "^9.0.1",
         "@types/web": "^0.0.96",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
@@ -369,9 +370,9 @@
       "dev": true
     },
     "node_modules/@types/jsrsasign": {
-      "version": "10.5.5",
-      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.5.tgz",
-      "integrity": "sha512-M2Et4hgTigFoArTu6ylK3hYFEH+UuXfgFXRXZ+flpCfux8j7fQ2D+0zEwiu6ehx0h5otaauhLSFzMzEtNA784A==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.8.tgz",
+      "integrity": "sha512-1oZ3TbarAhKtKUpyrCIqXpbx3ZAfoSulleJs6/UzzyYty0ut+kjRX7zHLAaHwVIuw8CBjIymwW4J2LK944HoHQ==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -1610,6 +1611,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dexie": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.3.tgz",
+      "integrity": "sha512-iHayBd4UYryDCVUNa3PMsJMEnd8yjyh5p7a+RFeC8i8n476BC9wMhVvqiImq5zJZJf5Tuer+s4SSj+AA3x+ZbQ==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/di": {
@@ -3461,9 +3470,9 @@
       }
     },
     "node_modules/jsrsasign": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
-      "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
+      "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw==",
       "funding": {
         "url": "https://github.com/kjur/jsrsasign#donations"
       }
@@ -6017,9 +6026,9 @@
       "dev": true
     },
     "@types/jsrsasign": {
-      "version": "10.5.5",
-      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.5.tgz",
-      "integrity": "sha512-M2Et4hgTigFoArTu6ylK3hYFEH+UuXfgFXRXZ+flpCfux8j7fQ2D+0zEwiu6ehx0h5otaauhLSFzMzEtNA784A==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.8.tgz",
+      "integrity": "sha512-1oZ3TbarAhKtKUpyrCIqXpbx3ZAfoSulleJs6/UzzyYty0ut+kjRX7zHLAaHwVIuw8CBjIymwW4J2LK944HoHQ==",
       "dev": true
     },
     "@types/minimist": {
@@ -6915,6 +6924,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true
+    },
+    "dexie": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.3.tgz",
+      "integrity": "sha512-iHayBd4UYryDCVUNa3PMsJMEnd8yjyh5p7a+RFeC8i8n476BC9wMhVvqiImq5zJZJf5Tuer+s4SSj+AA3x+ZbQ=="
     },
     "di": {
       "version": "0.0.1",
@@ -8282,9 +8296,9 @@
       }
     },
     "jsrsasign": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
-      "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw=="
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
+      "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw=="
     },
     "karma": {
       "version": "6.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,8 +1,9 @@
 {
   "dependencies": {
+    "dexie": "^3.2.3",
     "google-protobuf": "^3.21.2",
     "grpc-web": "^1.4.2",
-    "jsrsasign": "^10.6.1",
+    "jsrsasign": "^10.8.6",
     "uuid": "^9.0.0"
   },
   "main": "dist/index.js",
@@ -20,7 +21,7 @@
     "url": "git@github.com:scalar-labs/scalardl-javascript-client-sdk.git"
   },
   "devDependencies": {
-    "@types/jsrsasign": "^10.5.5",
+    "@types/jsrsasign": "^10.5.8",
     "@types/uuid": "^9.0.1",
     "@types/web": "^0.0.96",
     "@typescript-eslint/eslint-plugin": "^5.49.0",


### PR DESCRIPTION
This PR implements the `ClientServiceWithIndexedDb` class.

In short, if we use this class to create a ClientService, this class will store the key and certificate configured in the properties in browser's indexedDB. On the other hand, if the key and certificate are not configured in the properties, this class tries to load the key and certificate from the indexedDB, fill into the properties and then create a ClientService.

This class is the port of https://github.com/scalar-labs/scalardl-web-client-sdk/blob/master/indexdb.js but it has a bit differences

## Creation

Before
```
const clientService = await new ClientServiceWithIndexedDb(new ClientService(properties));
```

After
```
const clientService = await ClientServiceWithIndexedDb.create(properties);
```

The reason for doing this is because ClientService will check properties when it is being created now so that we need to load the key and certificate into the properties before the ClientService is created.

Although it's a breaking change but I think it should be ok because we don't have any web application now and ClientServiceWithIndexedDb support is not the main class like ClientService.

## Certificate management

ClientServiceWithIndexedDb now not only store/load keys but also *certificates*. I think it make more sense than just managing key but not including certificate. The benefit of using ClientServiceWithIndexedDb is it makes the applications possible to not ask users to use their keys/certificates all the time and could be be more user-friendly. If we only support store/load keys then users still need to provide their certificates to initiate a ScalarDL client.